### PR TITLE
Change handlerfunc signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ if err = bus.On(bus.ListenerConfig{
   Channel:     "test_on",
   HandlerFunc: handler,
   HandlerConcurrency: 4,
-
 }); err != nil {
   // handle failure to listen a message
 }
@@ -64,13 +63,13 @@ topic := "user_signup"
 emitter, err = bus.NewEmitter(bus.EmitterConfig{})
 
 e := event{Login: "rafa", Password: "ilhabela_is_the_place"}
-if err := bus.Request(topic, &e, handler); err != nil {
+if err = bus.Request(topic, &e, handler); err != nil {
   // handle failure to listen a message
 }
 
 func handler(payload []byte) (reply interface{}, err error) {
   e := event{}
-  if err := json.Unmarshal(payload, &e); err != nil {
+  if err = json.Unmarshal(payload, &e); err != nil {
     // handle failure
   }
   reply = &Reply{}

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ if err = emitter.EmitAsync(topic, &e); err != nil {
 import "github.com/rafaeljesus/nsq-event-bus"
 
 if err = bus.On(bus.ListenerConfig{
-  Topic:       "topic",
-  Channel:     "test_on",
-  HandlerFunc: handler,
+  Topic:              "topic",
+  Channel:            "test_on",
+  HandlerFunc:        handler,
   HandlerConcurrency: 4,
 }); err != nil {
   // handle failure to listen a message

--- a/emitter_test.go
+++ b/emitter_test.go
@@ -1,7 +1,6 @@
 package bus
 
 import (
-	"encoding/json"
 	"sync"
 	"testing"
 )
@@ -45,9 +44,9 @@ func TestEmitterRequest(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	replyHandler := func(payload []byte) (reply interface{}, err error) {
+	replyHandler := func(message *Message) (reply interface{}, err error) {
 		e := event{}
-		if err = json.Unmarshal(payload, &e); err != nil {
+		if err = message.DecodePayload(&e); err != nil {
 			t.Errorf("Expected to unmarshal payload")
 		}
 
@@ -55,16 +54,18 @@ func TestEmitterRequest(t *testing.T) {
 			t.Errorf("Expected name to be equal event %s", e.Name)
 		}
 
+		message.Finish()
 		wg.Done()
 		return
 	}
 
-	handler := func(payload []byte) (reply interface{}, err error) {
+	handler := func(message *Message) (reply interface{}, err error) {
 		e := event{}
-		if err = json.Unmarshal(payload, &e); err != nil {
+		if err = message.DecodePayload(&e); err != nil {
 			t.Errorf("Expected to unmarshal payload")
 		}
 		reply = &event{"event_reply"}
+		message.Finish()
 		return
 	}
 

--- a/listener_test.go
+++ b/listener_test.go
@@ -1,7 +1,6 @@
 package bus
 
 import (
-	"encoding/json"
 	"sync"
 	"testing"
 )
@@ -22,9 +21,9 @@ func TestListenerOn(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	handler := func(payload []byte) (reply interface{}, err error) {
+	handler := func(message *Message) (reply interface{}, err error) {
 		e := event{}
-		if err = json.Unmarshal(payload, &e); err != nil {
+		if err = message.DecodePayload(&e); err != nil {
 			t.Errorf("Expected to unmarshal payload")
 		}
 
@@ -32,6 +31,7 @@ func TestListenerOn(t *testing.T) {
 			t.Errorf("Expected name to be equal event %s", e.Name)
 		}
 
+		message.Finish()
 		wg.Done()
 		return
 	}

--- a/message.go
+++ b/message.go
@@ -1,6 +1,18 @@
 package bus
 
+import (
+	"encoding/json"
+	nsq "github.com/nsqio/go-nsq"
+)
+
 type Message struct {
+	*nsq.Message
 	ReplyTo string
 	Payload []byte
+}
+
+func (m *Message) DecodePayload(v interface{}) (err error) {
+	err = json.Unmarshal(m.Payload, v)
+
+	return
 }


### PR DESCRIPTION
This PR exposes the `bus.Message` which wraps `nsq.Message` allowing developers to handle messages pretty like the `nsq.Message`

closes https://github.com/rafaeljesus/nsq-event-bus/issues/7