### PR TITLE
Fix default value from EmitterConfig Address

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -63,8 +63,8 @@ type EventEmitter struct {
 func NewEmitter(ec EmitterConfig) (emitter Emitter, err error) {
 	config := newEmitterConfig(ec)
 
-	var address string
-	if len(ec.Address) == 0 {
+	address := ec.Address
+	if len(address) == 0 {
 		address = "localhost:4150"
 	}
 

--- a/emitter_test.go
+++ b/emitter_test.go
@@ -5,6 +5,31 @@ import (
 	"testing"
 )
 
+func TestNewEmitter(t *testing.T) {
+	var addressesTest = []struct {
+		addr   string
+		expect string
+	}{
+		{"", "localhost:4150"},
+		{"new-address", "new-address"},
+	}
+
+	for _, a := range addressesTest {
+		emitter, err := NewEmitter(EmitterConfig{
+			Address: a.addr,
+		})
+
+		if err != nil {
+			t.Errorf("Expected to initialize emitter %s", err)
+		}
+
+		e := emitter.(*EventEmitter)
+		if e.String() != a.expect {
+			t.Errorf("Expected emitter address %s, got %s", a.expect, e.String())
+		}
+	}
+}
+
 func TestEmitterEmit(t *testing.T) {
 	emitter, err := NewEmitter(EmitterConfig{})
 	if err != nil {


### PR DESCRIPTION
Fixed default value to Producer's address.

```
# before changes
nsq-event-bus (fix-conf-address)$ go test -run TestNewEmitter
--- FAIL: TestNewEmitter (0.00s)
	emitter_test.go:19: Expected emitter address "new-address", got "" 
FAIL
exit status 1
FAIL	github.com/rafaeljesus/nsq-event-bus	0.003s

# after changes
nsq-event-bus (fix-conf-address)$ go test -run TestNewEmitter
PASS
ok  	github.com/rafaeljesus/nsq-event-bus	0.004s
```